### PR TITLE
Tests unitarios de UrlQRCodeField

### DIFF
--- a/tests/test_qrbase.py
+++ b/tests/test_qrbase.py
@@ -38,3 +38,49 @@ def test_qrcode_field_empty_string(qr_field):
         qr_field.to_internal_value("")
 
     assert str(exc_info.value) == "['Cannot generate QR code from empty text']"
+
+
+# --- Tests para UrlQRCodeField ---
+from rest_framework.serializers import Serializer
+from rest_framework.exceptions import ValidationError as DRFValidationError
+from drf_extra_fields.fields import UrlQRCodeField
+from PIL import Image
+
+class UrlQRCodeFieldTestSerializer(Serializer):
+    qr = UrlQRCodeField()
+
+@pytest.fixture
+def url_serializer():
+    return UrlQRCodeFieldTestSerializer
+
+def test_valid_url_generates_qr(url_serializer):
+    data = {"qr": "https://www.example.com"}
+    serializer = url_serializer(data=data)
+    assert serializer.is_valid(), serializer.errors
+
+    qr_file = serializer.validated_data["qr"]
+    assert qr_file.name.endswith(".png")
+
+    image = Image.open(qr_file)
+    assert image.format == "PNG"
+
+def test_invalid_url_scheme(url_serializer):
+    data = {"qr": "ftp://example.com"}
+    serializer = url_serializer(data=data)
+    assert not serializer.is_valid()
+    assert "qr" in serializer.errors
+    assert "The URL must begin with" in str(serializer.errors["qr"][0])
+
+def test_empty_url(url_serializer):
+    data = {"qr": ""}
+    serializer = url_serializer(data=data)
+    assert not serializer.is_valid()
+    assert "qr" in serializer.errors
+    assert "cannot be generated from an empty URL" in str(serializer.errors["qr"][0])
+
+def test_non_string_input(url_serializer):
+    data = {"qr": 12345}
+    serializer = url_serializer(data=data)
+    assert not serializer.is_valid()
+    assert "qr" in serializer.errors
+    assert "A text string (URL) was expected" in str(serializer.errors["qr"][0])


### PR DESCRIPTION
# **Tests unitarios de UrlQRCodeField**

Este conjunto de pruebas valida el comportamiento de la clase` UrlQRCodeField` diseñado para generar códigos QR a partir de URLs validos; aplica reglas especificas para asegurar que solo acepte URLs que comiencen con http:// o https://

## **Las pruebas cubren los siguientes casos:**

1. Generación exitosa de código QR cuando se recibe una URL valida.
2. Rechazo de URLs con esquemas no permitidos como (ftp://.)
3. Rechazo de entradas vacías o de tipo incorrecto como ejemplo: (números)
4. Verificación de que el archivo generado es una imagen PNG valida

<img width="1629" height="378" alt="Captura de pantalla 2025-08-19 192504" src="https://github.com/user-attachments/assets/da6df1f4-7ea0-4c99-9276-a01595992e25" />
